### PR TITLE
NEP-5 approve fix

### DIFF
--- a/nex/token/nep5.py
+++ b/nex/token/nep5.py
@@ -170,6 +170,10 @@ class NEP5Handler():
             print("Incorrect permission")
             return False
 
+        if amount < 0:
+            print("Negative amount")
+            return False
+
         from_balance = storage.get(t_owner)
 
         # cannot approve an amount that is
@@ -178,11 +182,10 @@ class NEP5Handler():
 
             approval_key = concat(t_owner, t_spender)
 
-            current_approved_balance = storage.get(approval_key)
-
-            new_approved_balance = current_approved_balance + amount
-
-            storage.put(approval_key, new_approved_balance)
+            if amount == 0:
+                storage.delete(approval_key)
+            else:
+                storage.put(approval_key, amount)
 
             OnApprove(t_owner, t_spender, amount)
 


### PR DESCRIPTION
* Updated the NEP-5 approve function so that it always replaces an existing value. This ensures the balance validation is meaningful, and it allows enforcement that the amount is never negative. In order to clear an allowance now, all you'd need to do is set the allowance to 0, which has the further optimization now of deleting the approval from storage.

proposed fix for #11 