### PR TITLE
Fix Storage.Put During Verification

### DIFF
--- a/ico_template.py
+++ b/ico_template.py
@@ -53,7 +53,7 @@ def Main(operation, args):
 
         crowdsale = Crowdsale()
 
-        return crowdsale.can_exchange(token, attachments, storage)
+        return crowdsale.can_exchange(token, attachments, storage, True)
 
 
     elif trigger == Application:


### PR DESCRIPTION
* The Verification process will fail with an error like "[I 180205 00:24:42 InteropService:304] method Neo.Storage.Put not found in ->" if you attempt to do a Storage.Put during the Verification Trigger. The solution is to track whether we are doing verification so that we skip the put in that case.