### PR TITLE
Fake transfers for unchecked amounts

### DIFF
--- a/nex/nep5.py
+++ b/nex/nep5.py
@@ -57,15 +57,15 @@ def do_transfer(ctx, t_from, t_to, amount):
 
     if CheckWitness(t_from):
 
-        if t_from == t_to:
-            print("transfer to self!")
-            return True
-
         from_val = Get(ctx, t_from)
 
         if from_val < amount:
             print("insufficient funds")
             return False
+
+        if t_from == t_to:
+            print("transfer to self!")
+            return True
 
         if from_val == amount:
             Delete(ctx, t_from)


### PR DESCRIPTION
When the "to" and "from" addresses are the same, the balance is not checked before return True.

This won’t produce any balance alteration but it would reflect transactions for amounts greater than the available funds.

If some software, third-party or API is watching these calls it can lead to a balance error.

I think is better to check the account balance before returning the value even for transfers to himself.