### PR TITLE
Bumping neo-python version

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -33,7 +33,7 @@ mmh3==2.5.1
 mock==2.0.0
 mpmath==1.0.0
 neo-boa==0.3.7
--e git+https://github.com/CityOfZion/neo-python.git@99727d2622198c5bb1e64868780482e5b5dd043d#egg=neo_python
+neo-python==0.8.4
 neo-python-rpc==0.1.8
 neocore==0.3.6
 numpy==1.14.1


### PR DESCRIPTION
```
Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-i1hxw5f7/warrant-ext/setup.py", line 4, in <module>
        from pip.req import parse_requirements
    ImportError: No module named 'pip.req'
```
Fixes https://github.com/capless/warrant/issues/96 